### PR TITLE
Allow all Syncoid options in syncoid_syncs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In order for Syncoid to replicate to a remote host, you must ensure that SSH acc
 | *`setting`* | `""` | Policy setting |
 
 All settings supported by Sanoid in templates are supported - see [sanoid.conf](https://github.com/jimsalterjrs/sanoid/blob/master/sanoid.conf) and [sanoid.defaults.conf](https://github.com/jimsalterjrs/sanoid/blob/master/sanoid.defaults.conf) for details
+Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Syncoid#options) are configurable via `syncoid_syncs`.
 
 #### `sanoid_datasets[]`
 | Variable | Default | Comments |
@@ -66,11 +67,11 @@ All settings supported by Sanoid in templates are supported - see [sanoid.conf](
 | :--- | :--- | :--- |
 | `syncoid_service_name` | `"syncoid"` | systemd service name for Syncoid |
 | `syncoid_timer_frequency` | `"daily"` | systemd service frequency for Syncoid |
-| `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts | 
-| `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use | 
-| `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key | 
+| `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts |
+| `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use |
+| `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
 | `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*`\|id_rsa}` | Path to SSH key for Syncoid to use |
-| `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory | 
+| `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
 
 ## Example
 

--- a/tasks/install-source.yaml
+++ b/tasks/install-source.yaml
@@ -50,6 +50,21 @@
     - findoid
     - sleepymutex
 
+- name: create config directory
+  file:
+    dest: "{{ sanoid_conf_dir }}"
+    state: directory
+    owner: root
+    group: root
+
+- name: copy sanoid.defaults.conf to config dir
+  copy:
+    src: "{{ sanoid_source_download_dir }}/sanoid.defaults.conf"
+    dest: "{{ sanoid_conf_dir }}"
+    remote_src: yes
+    mode: '0644'
+  become: true
+
 - name: set paths to binaries
   set_fact:
     sanoid_bin_path: "{{ sanoid_source_install_dir }}/sanoid"

--- a/tasks/install-source.yaml
+++ b/tasks/install-source.yaml
@@ -14,7 +14,7 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
-  with_items: "sanoid_prerequisites"
+  with_items: "{{ sanoid_prerequisites }}"
 
 - become: false
   delegate_to: localhost

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -22,7 +22,7 @@
     dest: "{{ sanoid_conf }}"
     owner: root
     group: root
-    mode: '0700'
+    mode: '0600'
 
 - name: enable sanoid prune service
   ansible.builtin.systemd:

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -7,12 +7,73 @@ After=zfs.target
 Type=oneshot
 {% for sync in syncoid_syncs %}
 ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
+{% if sync.identifier | default('') %}
+  --identifier={{ sync.identifier }} \
+{% endif %}
 {% if sync.force_delete | default(False) %}
   --force-delete \
 {% endif %}
 {% if sync.recursive | default(False) %}
   --recursive \
+{% if sync.skip_parent | default(False) %}
+  --skip-parent \ {# only relevant if --recursive #}
 {% endif %}
+{% endif %}
+{% if sync.compress | default('') %}
+  --compress={{ sync.compress }} \
+{% endif %}
+{% if sync.source_bwlimit | default('') %}
+  --source-bwlimit={{ sync.source_bwlimit }} \
+{% endif %}
+{% if sync.target_bwlimit | default('') %}
+  --target-bwlimit={{ sync.target_bwlimit }} \
+{% endif %}
+{% if sync.mbuffer_size | default('') %}
+  --mbuffer-size={{ sync.mbuffer_size }} \
+{% endif %}
+{% if sync.pv_options | default('') %}
+  --pv-options={{ sync.pv_options }} \
+{% endif %}
+{% if sync.no_stream | default(False) %}
+  --no-stream \
+{% endif %}
+{% if sync.no_sync_snap | default(False) %}
+  --no-sync-snap \
+{% if sync.create_bookmark | default(False) %}
+  --create-bookmark \
+{% endif %}
+{% endif %}
+{% if sync.keep_sync_snap | default(False) %}
+  --keep-sync-snap \
+{% endif %}
+{% if sync.preserve_recordsize | default(False) %}
+  --preserve-recordsize
+{% endif %}
+{% if sync.no_clone_rollback | default(False) %}
+  --no-clone-rollback \
+{% endif %}
+{% if sync.no_rollback | default(False) %}
+  --no-rollback \
+{% endif %}
+{% for sync_exclude in sync.exclude | default([]) %}
+  --exclude={{ sync_exclude }}
+{% endfor %}
+{% if sync.sendoptions | default('') %}
+  --sendoptions={{ sync.sendoptions }} \
+{% endif %}
+{% if sync.recvoptions | default('') %}
+  --recvoptions={{ sync.recvoptions }} \
+{% endif %}
+{% if sync.no_privilege_escalation | default(False) %}
+  --no-privilege-escalation \
+{% endif %}
+{% if sync.no_resume | default(False) %}
+  --no-resume \
+{% endif %}
+{% if sync.no_clone_handling | default(False) %}
+  --no-clone-handling \
+{% endif %}
+
 {% if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
 {% endif %}


### PR DESCRIPTION
This PR adds support for deploying nearly any syncoid option to the systemd unit that this role installs. The readme is also updated with a pointer to the syncoid documentation. The configuration keys for `syncoid_syncs` are identical to the syncoid options themselves, minus the leading double-dash and with intermediate dashes converted to underscores.

I also fixed a typo preventing deployment from source.

Fixes #2 