### PR TITLE
Add tasks to systemd service files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `recursive` | `"no"` | Copy child datasets |
 | `force_delete` | `"no"` | Remove destination datasets recursively |
 
+### Sanoid systemd Settings
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
+| `sanoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
+| `sanoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
+
 ### Syncoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
@@ -72,6 +78,9 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
 | `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*`\|id_rsa}` | Path to SSH key for Syncoid to use |
 | `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
+| `syncoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
+| `syncoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
+
 
 ## Example
 
@@ -122,4 +131,9 @@ syncoid_syncs:
     recursive: yes
   - src: zpoolname/dataset
     dest: zpoolname/dataset-backup
+    
+syncoid_systemd_ExecStartPre:
+  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid/start
+syncoid_systemd_ExecStartPost:
+  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid
 ```

--- a/templates/sanoid.service.j2
+++ b/templates/sanoid.service.j2
@@ -10,3 +10,13 @@ ConditionFileNotEmpty={{ sanoid_conf }}
 Environment=TZ=UTC
 Type=oneshot
 ExecStart={{ sanoid_path | default(sanoid_bin_path) }} --take-snapshots --verbose
+{% if sanoid_systemd_ExecStartPre is defined and sanoid_systemd_ExecStartPre %}
+{% for exec in sanoid_systemd_ExecStartPre %}
+ExecStartPre={{ exec }}
+{% endfor %}
+{% endif %}
+{% if sanoid_systemd_ExecStartPost is defined and sanoid_systemd_ExecStartPost %}
+{% for exec in sanoid_systemd_ExecStartPost %}
+ExecStartPost={{ exec }}
+{% endfor %}
+{% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -73,7 +73,6 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
 {% if sync.no_clone_handling | default(False) %}
   --no-clone-handling \
 {% endif %}
-
 {% if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -87,3 +87,13 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   {{ sync.dest }}
 {% endif %}
 {% endfor %}
+{% if syncoid_systemd_ExecStartPre is defined and syncoid_systemd_ExecStartPre %}
+{% for exec in syncoid_systemd_ExecStartPre %}
+ExecStartPre={{ exec }}
+{% endfor %}
+{% endif %}
+{% if syncoid_systemd_ExecStartPost is defined and syncoid_systemd_ExecStartPost %}
+{% for exec in syncoid_systemd_ExecStartPost %}
+ExecStartPost={{ exec }}
+{% endfor %}
+{% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -47,7 +47,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --keep-sync-snap \
 {% endif %}
 {% if sync.preserve_recordsize | default(False) %}
-  --preserve-recordsize
+  --preserve-recordsize \
 {% endif %}
 {% if sync.no_clone_rollback | default(False) %}
   --no-clone-rollback \
@@ -56,7 +56,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --no-rollback \
 {% endif %}
 {% for sync_exclude in sync.exclude | default([]) %}
-  --exclude={{ sync_exclude }}
+  --exclude={{ sync_exclude }} \
 {% endfor %}
 {% if sync.sendoptions | default('') %}
   --sendoptions={{ sync.sendoptions }} \


### PR DESCRIPTION
This allows for running commands before and after syncing. The variables need to be defined as a list. Multiple tasks are possible. I use this for pinging healtchecks.io for job monitoring.