### PR TITLE
Fix: remove empty line in syncoid.service.j2

### DIFF
--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -73,7 +73,6 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
 {% if sync.no_clone_handling | default(False) %}
   --no-clone-handling \
 {% endif %}
-
 {% if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
 {% endif %}


### PR DESCRIPTION
Without this patch the `syncoid.service` unit reports:

```
/lib/systemd/system/syncoid.service:13: Missing '=', ignoring line.
```

Including the patch produces less redundant log output.