### PR TITLE
Refactor syncoid systemd configuration and basic Healthchecks.io support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `recursive` | `"no"` | Copy child datasets |
 | `force_delete` | `"no"` | Remove destination datasets recursively |
 
+### Sanoid systemd Settings
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
+| `sanoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
+| `sanoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
+
 ### Syncoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
@@ -72,6 +78,9 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
 | `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*`\|id_rsa}` | Path to SSH key for Syncoid to use |
 | `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
+| `syncoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
+| `syncoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
+
 
 ## Example
 
@@ -122,4 +131,9 @@ syncoid_syncs:
     recursive: yes
   - src: zpoolname/dataset
     dest: zpoolname/dataset-backup
+    
+syncoid_systemd_ExecStartPre:
+  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid/start
+syncoid_systemd_ExecStartPost:
+  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Ansible role `exterrestris.sanoid`
 
-An Ansible role to install and configure automated ZFS snapshots and replication using [Sanoid/Syncoid](https://github.com/jimsalterjrs/sanoid)
+An Ansible role to install and configure automated ZFS snapshots and replication using [Sanoid/Syncoid](https://github.com/jimsalterjrs/sanoid) managed by systemd timers, with optional [Healthchecks.io](https://healthchecks.io) support via [runitor](https://github.com/bdd/runitor)
 
 ## Requirements
 
-- Sanoid package available in distribution
+- ZFS
 - systemd
 
 In order for Syncoid to replicate to a remote host, you must ensure that SSH access via public key authentication is correctly set up for the relevant users
@@ -15,6 +15,7 @@ In order for Syncoid to replicate to a remote host, you must ensure that SSH acc
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
 | `sanoid_install_from` | `"package"` | Install Sanoid from OS package or from GitHub |
+| `syncoid_healthchecks_install_runitor` | `false` | Install [runitor](https://github.com/bdd/runitor) for Healthchecks.io support<br>*When set to `true`, will install runitor only if there is at least one `syncoid_syncs` entry with `healthchecks` defined* |
 
 #### Install from source
 | Variable | Default | Comments |
@@ -25,14 +26,18 @@ In order for Syncoid to replicate to a remote host, you must ensure that SSH acc
 | `sanoid_source_install_dir` | `/usr/local/sbin` | Directory to install binaries to |
 | `sanoid_source_remove_package` | `yes` | Remove the OS package if installed |
 
-### Configuration
+#### Runitor/Healthchecks
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
-| `sanoid_datasets` | `[]` | List of datasets to snapshot |
+| `syncoid_healthchecks_runitor_github_url` | `https://github.com/bdd/runitor` | GitHub repo to download latest release from |
+| `syncoid_healthchecks_runitor_install_dir` | `/usr/local/sbin` | Directory to install runitor binary to |
+
+
+### Sanoid Configuration
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
 | `sanoid_templates` | Example templates from [sanoid.conf](https://github.com/jimsalterjrs/sanoid/blob/master/sanoid.conf) | List of policy templates |
-| `syncoid_syncs` | `[]` | List of datasets to replicate |
-| `syncoid_send_options` | `''` | Default additional options to pass to the zfs send command via `syncoid --sendoptions` |
-| `syncoid_recv_options` | `''` | Default additional options to pass to the zfs recieve command via `syncoid --recvoptions` |
+| `sanoid_datasets` | `[]` | List of datasets to snapshot |
 
 #### `sanoid_templates[]`
 | Variable | Default | Comments |
@@ -52,9 +57,34 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `process_children_only` | `"no"` | Do not include this dataset |
 | `overrides` | `[]` | List of template settings to override |
 
-#### `syncoid_syncs[]`
+#### systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
+| `sanoid_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid systemd service file |
+| `sanoid_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid systemd service file |
+| `sanoid_prune_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid Prune systemd service file |
+| `sanoid_prune_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid Prune systemd service file |
+
+
+### Syncoid Configuration
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
+| `syncoid_syncs` | `[]` | List of datasets to replicate |
+| `syncoid_send_options` | `""` | Default additional options to pass to the zfs send command via `syncoid --sendoptions` |
+| `syncoid_recv_options` | `""` | Default additional options to pass to the zfs recieve command via `syncoid --recvoptions` |
+| `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts |
+| `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use |
+| `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
+| `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*` \| id_rsa }` | Path to SSH key for Syncoid to use |
+| `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
+| `syncoid_update_known_hosts` | `yes` | Update known_hosts with src/destination host public keys. |
+
+#### `syncoid_syncs[]`
+A separate systemd service will be generated for each sync listed, grouped into a single systemd target triggered by a systemd timer. The generated services are configured to run one at a time, in the order they are listed
+
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
+| `name` | Auto-generated | Name to use for the generated systemd service.<br>*Specifying a human-readable name is highly recommended* |
 | `src` | *Required* | Source ZFS dataset |
 | `src_host` | `""` | Source host |
 | `src_user` | `"root"` | Source user. Ignored if `src_host` empty |
@@ -63,35 +93,33 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 | `dest_user` | `"root"` | Destination user. Ignored if `dest_host` empty |
 | `recursive` | `"no"` | Copy child datasets |
 | `force_delete` | `"no"` | Remove destination datasets recursively |
-| `send_options` | `''` | Additional options to pass to the zfs send command via `syncoid --sendoptions` |
-| `recv_options` | `''` | Additional options to pass to the zfs recieve command via `syncoid --recvoptions` |
+| `send_options` | `""` | Additional options to pass to the zfs send command via `syncoid --sendoptions` |
+| `recv_options` | `""` | Additional options to pass to the zfs recieve command via `syncoid --recvoptions` |
 
-### Sanoid systemd Settings
+#### systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
-| `sanoid_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid systemd service file |
-| `sanoid_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid systemd service file |
-| `sanoid_prune_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid Prune systemd service file |
-| `sanoid_prune_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid Prune systemd service file |
-
-### Syncoid systemd Settings
-| Variable | Default | Comments |
-| :--- | :--- | :--- |
-| `syncoid_service_name` | `"syncoid"` | systemd service name for Syncoid |
-| `syncoid_service_pre_start` | `[]` | Add ExecStartPre commands to the Syncoid systemd service file |
-| `syncoid_service_post_start` | `[]` | Add ExecStartPost commands to the Syncoid systemd service file |
+| `syncoid_service_name` | `"syncoid"` | Name to use for the Syncoid systemd target, and the prefix to use for the individual systemd sync services |
 | `syncoid_timer_frequency` | `"daily"` | systemd service frequency for Syncoid |
-| `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts |
-| `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use |
-| `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
-| `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*`\|id_rsa}` | Path to SSH key for Syncoid to use |
-| `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
-| `syncoid_update_known_hosts` | `yes` | Update known_hosts with src/destination host public keys. |
+| `syncoid_syncs[].systemd.pre_start` | `[]` | Add ExecStartPre commands to the systemd service file for the specific sync |
+| `syncoid_syncs[].systemd.post_start` | `[]` | Add ExecStartPost commands to the systemd service file for the specific sync |
 
+
+### Healthchecks.io
+| Variable | Default | Comments |
+| :--- | :--- | :--- |
+| `syncoid_healthchecks_api_url` | `"https://hc-ping.com"` | Default Healthchecks.io API URL to use |
+| `syncoid_healthchecks_ping_key` | `""` | Default project ping key to use |
+| `syncoid_syncs[].healthchecks.api_url` | `{{ syncoid_healthchecks_api_url }}` | API URL to use for the specific sync |
+| `syncoid_syncs[].healthchecks.ping_key` | `{{ syncoid_healthchecks_ping_key }}` | Project ping key to use for the specific sync |
+| `syncoid_syncs[].healthchecks.slug` | Required | Check slug to use for the specific sync |
 
 ## Example
 
 ```Yaml
+syncoid_healthchecks_install_runitor: true
+syncoid_healthchecks_ping_key: **project-ping-key**
+
 sanoid_templates:
   - name: production
     frequently: 0
@@ -132,15 +160,20 @@ sanoid_datasets:
       hourly: 4
 
 syncoid_syncs:
-  - src: zpoolname/parent
+  - name: main-backup
+    src: zpoolname/parent
     dest: zpoolname/parent-backup
     dest_host: remote
     recursive: yes
+    # Healthchecks.io ping via runitor
+    healthchecks:
+      slug: main-backup
   - src: zpoolname/dataset
     dest: zpoolname/dataset-backup
-    
-syncoid_service_pre_start:
-  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid/start
-syncoid_service_post_start:
-  - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid
+    # Manual Healthchecks.io ping via curl
+    systemd:
+      pre_start:
+        - "/usr/bin/curl https://hc-ping.com/**uuid**/start"
+      post_start:
+        - "/usr/bin/curl https://hc-ping.com/**uuid**"
 ```

--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 ### Sanoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
-| `sanoid_service_pre_start` | `[]` | Add ExecStartPre commands to the systemd service file |
-| `sanoid_service_post_start` | `[]` | Add ExecStartPost commands to the systemd service file |
+| `sanoid_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid systemd service file |
+| `sanoid_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid systemd service file |
+| `sanoid_prune_service_pre_start` | `[]` | Add ExecStartPre commands to the Sanoid Prune systemd service file |
+| `sanoid_prune_service_post_start` | `[]` | Add ExecStartPost commands to the Sanoid Prune systemd service file |
 
 ### Syncoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
 | `syncoid_service_name` | `"syncoid"` | systemd service name for Syncoid |
-| `syncoid_service_pre_start` | `[]` | Add ExecStartPre commands to the systemd service file |
-| `syncoid_service_post_start` | `[]` | Add ExecStartPost commands to the systemd service file |
+| `syncoid_service_pre_start` | `[]` | Add ExecStartPre commands to the Syncoid systemd service file |
+| `syncoid_service_post_start` | `[]` | Add ExecStartPost commands to the Syncoid systemd service file |
 | `syncoid_timer_frequency` | `"daily"` | systemd service frequency for Syncoid |
 | `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts |
 | `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use |

--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ Similarly, most [Syncoid flags](https://github.com/jimsalterjrs/sanoid/wiki/Sync
 ### Sanoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
-| `sanoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
-| `sanoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
+| `sanoid_service_pre_start` | `[]` | Add ExecStartPre commands to the systemd service file |
+| `sanoid_service_post_start` | `[]` | Add ExecStartPost commands to the systemd service file |
 
 ### Syncoid systemd Settings
 | Variable | Default | Comments |
 | :--- | :--- | :--- |
 | `syncoid_service_name` | `"syncoid"` | systemd service name for Syncoid |
+| `syncoid_service_pre_start` | `[]` | Add ExecStartPre commands to the systemd service file |
+| `syncoid_service_post_start` | `[]` | Add ExecStartPost commands to the systemd service file |
 | `syncoid_timer_frequency` | `"daily"` | systemd service frequency for Syncoid |
 | `syncoid_use_ssh_key` | `yes` | Use an SSH key to login to remote hosts |
 | `syncoid_generate_ssh_key` | `yes` | Generate an SSH key for Syncoid to use |
 | `syncoid_generated_ssh_key` | `id_syncoid` | Name of generated SSH key |
 | `syncoid_ssh_key` | `/root/.ssh/{`*`syncoid_generated_ssh_key`*`\|id_rsa}` | Path to SSH key for Syncoid to use |
 | `syncoid_ssh_key_install_remote` | `yes` | Install specified SSH key on remote hosts. Requires remote hosts to be defined in inventory |
-| `syncoid_systemd_ExecStartPre` | undefined | Add ExecStartPre commands to the systemd service file |
-| `syncoid_systemd_ExecStartPost` | undefined | Add ExecStartPost commands to the systemd service file |
 
 
 ## Example
@@ -132,8 +132,8 @@ syncoid_syncs:
   - src: zpoolname/dataset
     dest: zpoolname/dataset-backup
     
-syncoid_systemd_ExecStartPre:
+syncoid_service_pre_start:
   - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid/start
-syncoid_systemd_ExecStartPost:
+syncoid_service_post_start:
   - /usr/bin/curl https://hc-ping.com/{ ping id }/syncoid
 ```

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -124,4 +124,4 @@ syncoid_healthchecks_runitor_github_url: https://github.com/bdd/runitor
 syncoid_healthchecks_runitor_install_dir: /usr/local/sbin
 
 ## Config
-syncoid_healthchecks_api_url: ''
+syncoid_healthchecks_api_url: 'https://hc-ping.com'

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -46,8 +46,8 @@ sanoid_timer_frequency: '*:0/15'
 # ExecPreStart
 sanoid_prune_service_pre_start: []
 
-# ExecPOstStart
-sanoid_prune_service_pre_start: []
+# ExecPostStart
+sanoid_prune_service_post_start: []
 
 ### Syncoid
 ## Configuration

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -39,6 +39,9 @@ sanoid_service_pre_start: []
 # ExecPostStart
 sanoid_service_post_start: []
 
+# Timer enabled
+sanoid_timer_enabled: yes
+
 # Timer frequency
 sanoid_timer_frequency: '*:0/15'
 
@@ -48,6 +51,9 @@ sanoid_prune_service_pre_start: []
 
 # ExecPostStart
 sanoid_prune_service_post_start: []
+
+# Service enabled
+sanoid_prune_service_enabled: yes
 
 ### Syncoid
 ## Configuration

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
+### Installation
 # Install method: package or source
 sanoid_install_from: package
 
@@ -17,6 +18,8 @@ sanoid_source_version: latest
 # Remove sanoid package when installing from source
 sanoid_source_remove_package: yes
 
+### Sanoid
+## Configuration
 # Datasets to snapshot
 sanoid_datasets: []
 
@@ -29,19 +32,36 @@ sanoid_conf_dir: /etc/sanoid
 # Configuration file path
 sanoid_conf: "{{ sanoid_conf_dir }}/sanoid.conf"
 
-# systemd timer frequency
+## Systemd service
+# ExecPreStart
+sanoid_service_pre_start: []
+
+# ExecPostStart
+sanoid_service_post_start: []
+
+# Timer frequency
 sanoid_timer_frequency: '*:0/15'
 
+### Syncoid
+## Configuration
 # Replication pairs
 syncoid_syncs: []
 
-# systemd service name
+## Systemd service
+# Service name
 syncoid_service_name: syncoid
 
-# systemd timer frequency
+# ExecPreStart
+syncoid_service_pre_start: []
+
+# ExecPostStart
+syncoid_service_post_start: []
+
+# Timer frequency
 syncoid_timer_frequency: daily
 
-# systemd timer enabled
+## SSH configuration
+# Timer enabled
 syncoid_timer_enabled: yes
 
 # Use an SSH key to connect to remote hosts

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -60,6 +60,12 @@ sanoid_prune_service_enabled: yes
 # Replication pairs
 syncoid_syncs: []
 
+# Default ZFS send options
+syncoid_send_options: ''
+
+# Default ZFS recv options
+syncoid_recv_options: ''
+
 ## Systemd service
 # Service name
 syncoid_service_name: syncoid
@@ -73,10 +79,10 @@ syncoid_service_post_start: []
 # Timer frequency
 syncoid_timer_frequency: daily
 
-## SSH configuration
 # Timer enabled
 syncoid_timer_enabled: yes
 
+## SSH configuration
 # Use an SSH key to connect to remote hosts
 syncoid_use_ssh_key: yes
 
@@ -107,8 +113,3 @@ syncoid_ssh_key_install_remote: yes
 # Update known hosts
 syncoid_update_known_hosts: yes
 
-# Default syncoid ZFS send options
-syncoid_send_options: ''
-
-# Default syncoid ZFS recv options
-syncoid_recv_options: ''

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -42,6 +42,13 @@ sanoid_service_post_start: []
 # Timer frequency
 sanoid_timer_frequency: '*:0/15'
 
+## Systemd prune service
+# ExecPreStart
+sanoid_prune_service_pre_start: []
+
+# ExecPOstStart
+sanoid_prune_service_pre_start: []
+
 ### Syncoid
 ## Configuration
 # Replication pairs

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -113,3 +113,15 @@ syncoid_ssh_key_install_remote: yes
 # Update known hosts
 syncoid_update_known_hosts: yes
 
+### Healthchecks
+## Installation
+syncoid_healthchecks_install_runitor: false
+
+# Github Repo URL
+syncoid_healthchecks_runitor_github_url: https://github.com/bdd/runitor
+
+# Install directory
+syncoid_healthchecks_runitor_install_dir: /usr/local/sbin
+
+## Config
+syncoid_healthchecks_api_url: ''

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,0 +1,3 @@
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/tasks/install-package.yaml
+++ b/tasks/install-package.yaml
@@ -7,7 +7,7 @@
     update_cache: true
 
 - name: update sanoid-prune systemd service pre start overrides
-  import_tasks: "systemd-override.yaml"
+  ansible.builtin.include_tasks: "systemd-override.yaml"
   vars:
     systemd_service_name: sanoid-prune
     systemd_service_override_name: pre-start
@@ -15,7 +15,7 @@
     systemd_service_overrides: "{{ sanoid_prune_service_pre_start }}"
 
 - name: update sanoid-prune systemd service post start overrides
-  import_tasks: "systemd-override.yaml"
+  ansible.builtin.include_tasks: "systemd-override.yaml"
   vars:
     systemd_service_name: sanoid-prune
     systemd_service_override_name: post-start
@@ -23,7 +23,7 @@
     systemd_service_overrides: "{{ sanoid_prune_service_post_start }}"
 
 - name: update sanoid systemd service pre start overrides
-  import_tasks: "systemd-override.yaml"
+  ansible.builtin.include_tasks: "systemd-override.yaml"
   vars:
     systemd_service_name: sanoid
     systemd_service_override_name: pre-start
@@ -31,7 +31,7 @@
     systemd_service_overrides: "{{ sanoid_service_pre_start }}"
 
 - name: update sanoid systemd service post start overrides
-  import_tasks: "systemd-override.yaml"
+  ansible.builtin.include_tasks: "systemd-override.yaml"
   vars:
     systemd_service_name: sanoid
     systemd_service_override_name: post-start

--- a/tasks/install-package.yaml
+++ b/tasks/install-package.yaml
@@ -5,3 +5,35 @@
     name: sanoid
     state: present
     update_cache: true
+
+- name: update sanoid-prune systemd service pre start overrides
+  import_tasks: "systemd-override.yaml"
+  vars:
+    systemd_service_name: sanoid-prune
+    systemd_service_override_name: pre-start
+    systemd_service_override_type: ExecPreStart
+    systemd_service_overrides: "{{ sanoid_prune_service_pre_start }}"
+
+- name: update sanoid-prune systemd service post start overrides
+  import_tasks: "systemd-override.yaml"
+  vars:
+    systemd_service_name: sanoid-prune
+    systemd_service_override_name: post-start
+    systemd_service_override_type: ExecPostStart
+    systemd_service_overrides: "{{ sanoid_prune_service_post_start }}"
+
+- name: update sanoid systemd service pre start overrides
+  import_tasks: "systemd-override.yaml"
+  vars:
+    systemd_service_name: sanoid
+    systemd_service_override_name: pre-start
+    systemd_service_override_type: ExecPreStart
+    systemd_service_overrides: "{{ sanoid_service_pre_start }}"
+
+- name: update sanoid systemd service post start overrides
+  import_tasks: "systemd-override.yaml"
+  vars:
+    systemd_service_name: sanoid
+    systemd_service_override_name: post-start
+    systemd_service_override_type: ExecPostStart
+    systemd_service_overrides: "{{ sanoid_service_post_start }}"

--- a/tasks/install-runitor.yaml
+++ b/tasks/install-runitor.yaml
@@ -1,0 +1,24 @@
+---
+- become: false
+  delegate_to: localhost
+  run_once: true
+  block:
+  - name: get latest release version from GitHub
+    ansible.builtin.uri:
+      url: "{{ syncoid_healthchecks_runitor_github_url }}/releases/latest"
+    register: syncoid_healthchecks_runitor_github_release_page
+  - name: Set version and download URL facts
+    set_fact:
+      syncoid_healthchecks_runitor_version: "{{ syncoid_healthchecks_runitor_github_release_page['url'].split('/')[-1] }}"
+      syncoid_healthchecks_runitor_download_base_url: "{{ syncoid_healthchecks_runitor_github_release_page['url'].replace('/tag/', '/download/') }}"
+
+- name: download binary from GitHub
+  ansible.builtin.get_url:
+    url: "{{ syncoid_healthchecks_runitor_download_base_url }}/runitor-{{ syncoid_healthchecks_runitor_version }}-linux-amd64"
+    # checksum: "sha256:{{ syncoid_healthchecks_runitor_download_base_url }}/SHA256"
+    dest: "{{ syncoid_healthchecks_runitor_install_dir }}/runitor"
+    mode: '0700'
+
+- name: set path to binary
+  set_fact:
+    syncoid_healthchecks_runitor_binary: "{{ syncoid_healthchecks_runitor_install_dir }}/runitor"

--- a/tasks/install-source.yaml
+++ b/tasks/install-source.yaml
@@ -21,16 +21,16 @@
   run_once: true
   block:
   - name: get latest release versiom from GitHub
-    uri:
+    ansible.builtin.uri:
       url: "{{ sanoid_source_github_url }}/releases/latest"
     register: sanoid_github_release_page
   - name: Set latest version fact
-    set_fact:
+    ansible.builtin.set_fact:
       sanoid_source_version: "{{ sanoid_github_release_page['url'].split('/')[-1] }}"
   when: sanoid_source_version == "latest"
 
 - name: clone GitHub repo
-  git:
+  ansible.builtin.git:
     repo: "{{ sanoid_source_github_url }}"
     dest: "{{ sanoid_source_download_dir }}"
     version: "{{ sanoid_source_version }}"
@@ -38,7 +38,7 @@
     force: yes
 
 - name: copy binaries
-  copy:
+  ansible.builtin.copy:
     src: "{{ sanoid_source_download_dir }}/{{ item }}"
     dest: "{{ sanoid_source_install_dir }}"
     remote_src: yes
@@ -51,14 +51,14 @@
     - sleepymutex
 
 - name: create config directory
-  file:
+  ansible.builtin.file:
     dest: "{{ sanoid_conf_dir }}"
     state: directory
     owner: root
     group: root
 
 - name: copy sanoid.defaults.conf to config dir
-  copy:
+  ansible.builtin.copy:
     src: "{{ sanoid_source_download_dir }}/sanoid.defaults.conf"
     dest: "{{ sanoid_conf_dir }}"
     remote_src: yes
@@ -66,18 +66,18 @@
   become: true
 
 - name: set paths to binaries
-  set_fact:
+  ansible.builtin.set_fact:
     sanoid_bin_path: "{{ sanoid_source_install_dir }}/sanoid"
     syncoid_bin_path: "{{ sanoid_source_install_dir }}/syncoid"
 
 - name: set up sanoid-prune systemd service
-  import_tasks: "systemd-add.yaml"
+  ansible.builtin.include_tasks: "systemd-add.yaml"
   vars:
     systemd_service_name: sanoid-prune
     systemd_service_template: sanoid-prune.service.j2
 
 - name: set up sanoid systemd service
-  import_tasks: "systemd-add.yaml"
+  ansible.builtin.include_tasks: "systemd-add.yaml"
   vars:
     systemd_service_name: sanoid
     systemd_service_template: sanoid.service.j2

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -86,7 +86,7 @@
             state: started
             enabled: "{{ syncoid_timer_enabled }}"
             masked: no
-            daemon_reload: yes
+          notify: reload systemd
   when:
     - syncoid_syncs is not none
     - syncoid_syncs | length > 0

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -5,9 +5,15 @@
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yaml"
     - "{{ ansible_distribution }}.yaml"
     - "{{ ansible_os_family }}.yaml"
+  tags:
+    - sanoid
+    - syncoid
 
 - name: include install tasks
   ansible.builtin.include_tasks: "install-{{ sanoid_install_from }}.yaml"
+  tags:
+    - sanoid
+    - syncoid
 
 - name: create config directory
   ansible.builtin.file:
@@ -15,6 +21,8 @@
     state: directory
     owner: root
     group: root
+  tags:
+    - sanoid
 
 - name: generate sanoid config
   ansible.builtin.template:
@@ -23,12 +31,16 @@
     owner: root
     group: root
     mode: '0600'
+  tags:
+    - sanoid
 
 - name: enable sanoid prune service
   ansible.builtin.systemd:
     name: sanoid-prune.service
     masked: no
     enabled: "{{ sanoid_prune_service_enabled }}"
+  tags:
+    - sanoid
 
 - name: enable sanoid timer
   ansible.builtin.systemd:
@@ -36,6 +48,8 @@
     state: started
     masked: no
     enabled: "{{ sanoid_timer_enabled }}"
+  tags:
+    - sanoid
 
 - name: configure syncoid service
   block:
@@ -169,6 +183,8 @@
   when:
     - syncoid_syncs is not none
     - syncoid_syncs | length > 0
+  tags:
+    - syncoid
 
 - name: remove syncoid service
   block:
@@ -201,3 +217,5 @@
         systemd_service_name: "{{ syncoid_service_name }}"
         systemd_service_type: target
   when: (syncoid_syncs is none) or (syncoid_syncs | length == 0)
+  tags:
+    - syncoid

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,16 +1,16 @@
 ---
 - name: include os specific variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yaml"
     - "{{ ansible_distribution }}.yaml"
     - "{{ ansible_os_family }}.yaml"
 
 - name: include install tasks
-  include_tasks: "install-{{ sanoid_install_from }}.yaml"
+  ansible.builtin.include_tasks: "install-{{ sanoid_install_from }}.yaml"
 
 - name: create config directory
-  file:
+  ansible.builtin.file:
     dest: "{{ sanoid_conf_dir }}"
     state: directory
     owner: root

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -95,14 +95,64 @@
             - "{{ syncoid_syncs }}"
       when: syncoid_update_known_hosts
 
-    - name: set up syncoid systemd service
+    - name: set up syncoid systemd target, timer and services
       block:
-        - name: set up syncoid systemd service
-          import_tasks: "systemd-add.yaml"
+        - name: compile syncoid service names
+          ansible.builtin.set_fact:
+            syncoid_sync_names: >-
+              {{ syncoid_sync_names + [ item.name | default(item | to_json | hash('md5')) ] }}
+            syncoid_service_names: >-
+              {{ syncoid_service_names + [ syncoid_service_name ~ '-' ~ item.name | default(item | to_json | hash('md5')) ] }}
+          vars:
+            syncoid_sync_names: []
+            syncoid_service_names: []
+          loop: "{{ syncoid_syncs | flatten }}"
+
+        - name: get current syncoid services
+          ansible.builtin.systemd:
+            name: "{{ syncoid_service_name }}.target"
+          register: syncoid_target
+
+        - name: compile current syncoid service names
+          ansible.builtin.set_fact:
+            syncoid_current_service_names: "{{ syncoid_target.status.Wants | default('') | split(' ') | map('replace', '.service', '') }}"
+
+        - name: compile syncoid services to remove
+          ansible.builtin.set_fact:
+            syncoid_unused_service_names: "{{ syncoid_current_service_names | difference(syncoid_service_names) }}"
+
+        - name: update syncoid systemd sync services
+          ansible.builtin.include_tasks: "systemd-add.yaml"
+          vars:
+            systemd_service_name: "{{ item.1 }}"
+            systemd_service_template: syncoid.service.j2
+            syncoid_sync_name: "{{ item.0 }}"
+            syncoid_sync: "{{ item.2 }}"
+            syncoid_after_services: "{{ syncoid_service_names[:idx] }}"
+          loop: "{{ syncoid_sync_names | zip(syncoid_service_names, syncoid_syncs) | list }}"
+          loop_control:
+            label: "{{ item.0 }}"
+            index_var: idx
+
+        - name: remove unused syncoid sync services
+          ansible.builtin.include_tasks: "systemd-remove.yaml"
+          vars:
+            systemd_service_name: "{{ item }}"
+          loop: "{{ syncoid_unused_service_names }}"
+
+        - name: remove syncoid service unit if present
+          ansible.builtin.include_tasks: "systemd-remove.yaml"
           vars:
             systemd_service_name: "{{ syncoid_service_name }}"
-            systemd_service_template: syncoid.service.j2
+            systemd_remove_timer: false
+
+        - name: set up syncoid target and timer
+          ansible.builtin.include_tasks: "systemd-add.yaml"
+          vars:
+            systemd_service_name: "{{ syncoid_service_name }}"
+            systemd_target_template: syncoid.target.j2
             systemd_timer_template: syncoid.timer.j2
+
         - name: enable syncoid timer
           ansible.builtin.systemd:
             name: "{{ syncoid_service_name }}.timer"
@@ -115,7 +165,33 @@
     - syncoid_syncs | length > 0
 
 - name: remove syncoid service
-  import_tasks: "systemd-remove.yaml"
-  vars:
-    systemd_service_name: "{{ syncoid_service_name }}"
+  block:
+    - name: get current syncoid services
+      ansible.builtin.systemd:
+        name: "{{ syncoid_service_name }}.target"
+      register: syncoid_target
+
+    - name: compile current syncoid service names
+      ansible.builtin.set_fact:
+        syncoid_unused_service_names: "{{ syncoid_target.status.Wants | default('') | split(' ') | map('replace', '.service', '') }}"
+
+    - name: disable syncoid timer
+      ansible.builtin.systemd:
+        name: "{{ syncoid_service_name }}.timer"
+        state: started
+        enabled: false
+        masked: no
+      notify: reload systemd
+
+    - name: remove syncoid systemd sync services
+      ansible.builtin.include_tasks: "systemd-remove.yaml"
+      vars:
+        systemd_service_name: "{{ item }}"
+      loop: "{{ syncoid_unused_service_names }}"
+
+    - name: remove syncoid service
+      ansible.builtin.include_tasks: "systemd-remove.yaml"
+      vars:
+        systemd_service_name: "{{ syncoid_service_name }}"
+        systemd_service_type: target
   when: (syncoid_syncs is none) or (syncoid_syncs | length == 0)

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -95,6 +95,12 @@
             - "{{ syncoid_syncs }}"
       when: syncoid_update_known_hosts
 
+    - name: install runitor
+      ansible.builtin.include_tasks: "install-runitor.yaml"
+      when:
+        - syncoid_healthchecks_install_runitor
+        - syncoid_syncs | selectattr('healthchecks', 'defined') | list | length > 0
+
     - name: set up syncoid systemd target, timer and services
       block:
         - name: compile syncoid service names

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -28,14 +28,14 @@
   ansible.builtin.systemd:
     name: sanoid-prune.service
     masked: no
-    enabled: yes
+    enabled: "{{ sanoid_prune_service_enabled }}"
 
 - name: enable sanoid timer
   ansible.builtin.systemd:
     name: sanoid.timer
     state: started
     masked: no
-    enabled: yes
+    enabled: "{{ sanoid_timer_enabled }}"
 
 - name: configure syncoid service
   block:

--- a/tasks/systemd-add.yaml
+++ b/tasks/systemd-add.yaml
@@ -6,6 +6,7 @@
     owner: root
     group: root
     mode: '0700'
+  notify: reload systemd
 - name: generate systemd timer unit file
   ansible.builtin.template:
     src: "{{ systemd_timer_template }}"
@@ -14,4 +15,5 @@
     group: root
     mode: '0700'
   when: systemd_timer_template is defined
+  notify: reload systemd
 

--- a/tasks/systemd-add.yaml
+++ b/tasks/systemd-add.yaml
@@ -5,7 +5,7 @@
     dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.service"
     owner: root
     group: root
-    mode: '0700'
+    mode: '0644'
   notify: reload systemd
 - name: generate systemd timer unit file
   ansible.builtin.template:
@@ -13,7 +13,7 @@
     dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
     owner: root
     group: root
-    mode: '0700'
+    mode: '0644'
   when: systemd_timer_template is defined
   notify: reload systemd
 

--- a/tasks/systemd-add.yaml
+++ b/tasks/systemd-add.yaml
@@ -1,13 +1,23 @@
 ---
-- name: generate systemd service unit file
+- name: generate systemd service unit file for {{ systemd_service_name }}
   ansible.builtin.template:
     src: "{{ systemd_service_template }}"
     dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.service"
     owner: root
     group: root
     mode: '0644'
+  when: systemd_service_template is defined
   notify: reload systemd
-- name: generate systemd timer unit file
+- name: generate systemd target unit file for {{ systemd_service_name }}
+  ansible.builtin.template:
+    src: "{{ systemd_target_template }}"
+    dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.target"
+    owner: root
+    group: root
+    mode: '0644'
+  when: systemd_target_template is defined
+  notify: reload systemd
+- name: generate systemd timer unit file for {{ systemd_service_name }}
   ansible.builtin.template:
     src: "{{ systemd_timer_template }}"
     dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"

--- a/tasks/systemd-override.yaml
+++ b/tasks/systemd-override.yaml
@@ -12,7 +12,7 @@
         dest: "/etc/systemd/system/{{ systemd_service_name }}.d/{{ systemd_service_override_name }}.conf"
         owner: root
         group: root
-        mode: '0700'
+        mode: '0644'
       notify: reload systemd
   when:
     - systemd_service_overrides is not none

--- a/tasks/systemd-override.yaml
+++ b/tasks/systemd-override.yaml
@@ -1,0 +1,32 @@
+---
+- block:
+    - name: create systemd service override directory
+      ansible.builtin.file:
+        dest: "/etc/systemd/system/{{ systemd_service_name }}.d/"
+        state: directory
+        owner: root
+        group: root
+    - name: generate systemd service override
+      ansible.builtin.template:
+        src: ../templates/service.override.conf.j2
+        dest: "/etc/systemd/system/{{ systemd_service_name }}.d/{{ systemd_service_override_name }}.conf"
+        owner: root
+        group: root
+        mode: '0700'
+      notify: reload systemd
+  when:
+    - systemd_service_overrides is not none
+    - systemd_service_overrides | length > 0
+  
+- block:
+    - name: check systemd service override exists
+      stat:
+        path: "/etc/systemd/system/{{ systemd_service_name }}.d/{{ systemd_service_override_name }}.conf"
+      register: override_exists
+    - name: remove systemd service override
+      file:
+        dest: "/etc/systemd/system/{{ systemd_service_name }}.d/{{ systemd_service_override_name }}.conf"
+        state: absent
+      notify: reload systemd
+      when: override_exists.stat.exists
+  when: (systemd_service_overrides is none) or (systemd_service_overrides | length == 0)

--- a/tasks/systemd-remove.yaml
+++ b/tasks/systemd-remove.yaml
@@ -18,11 +18,10 @@
         dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
         state: absent
       when: timer_exists.stat.exists
+      notify: reload systemd
     - name: remove systemd service unit file
       file:
         dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.service"
         state: absent
-    - name: reload systemd
-      ansible.builtin.systemd:
-        daemon_reload: yes
+      notify: reload systemd
   when: service_exists.stat.exists

--- a/tasks/systemd-remove.yaml
+++ b/tasks/systemd-remove.yaml
@@ -1,27 +1,29 @@
 ---
-- name: check systemd service exists
+- name: check systemd {{ systemd_service_type | default('service') }} {{ systemd_service_name }} exists
   stat:
-    path: "/usr/lib/systemd/system/{{ systemd_service_name }}.service"
+    path: "/usr/lib/systemd/system/{{ systemd_service_name }}.{{ systemd_service_type | default('service') }}"
   register: service_exists
 - block:
-    - name: check if systemd service has timer
-      stat:
-        path: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
-      register: timer_exists
-    - name: disable systemd service
-      ansible.builtin.systemd:
-        name: "{{ systemd_service_name }}.{{ 'timer' if timer_exists.stat.exists else 'service' }}"
-        state: stopped
-        enabled: no
-    - name: remove systemd timer unit file
+    - block:
+        - name: check if systemd {{ systemd_service_type | default('service') }} {{ systemd_service_name }} has timer
+          stat:
+            path: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
+          register: timer_exists
+        - name: disable systemd service
+          ansible.builtin.systemd:
+            name: "{{ systemd_service_name }}.{{ 'timer' if timer_exists.stat.exists else systemd_service_type | default('service') }}"
+            state: stopped
+            enabled: no
+        - name: remove systemd {{ systemd_service_name }} timer unit file
+          file:
+            dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
+            state: absent
+          when: timer_exists.stat.exists
+          notify: reload systemd
+      when: systemd_remove_timer | default(true)
+    - name: remove systemd {{ systemd_service_type | default('service') }} {{ systemd_service_name }} unit file
       file:
-        dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.timer"
-        state: absent
-      when: timer_exists.stat.exists
-      notify: reload systemd
-    - name: remove systemd service unit file
-      file:
-        dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.service"
+        dest: "/usr/lib/systemd/system/{{ systemd_service_name }}.{{ systemd_service_type | default('service') }}"
         state: absent
       notify: reload systemd
   when: service_exists.stat.exists

--- a/templates/sanoid-prune.service.j2
+++ b/templates/sanoid-prune.service.j2
@@ -8,6 +8,16 @@ ConditionFileNotEmpty={{ sanoid_conf }}
 Environment=TZ=UTC
 Type=oneshot
 ExecStart={{ sanoid_path | default(sanoid_bin_path) }} --prune-snapshots --verbose
+{% if sanoid_prune_service_pre_start is defined and sanoid_prune_service_pre_start %}
+{%  for exec in sanoid_prune_service_pre_start %}
+ExecStartPre={{ exec }}
+{%  endfor %}
+{% endif %}
+{% if sanoid_prune_service_post_start is defined and sanoid_prune_service_post_start %}
+{%  for exec in sanoid_prune_service_post_start %}
+ExecStartPost={{ exec }}
+{%  endfor %}
+{% endif %}
 
 [Install]
 WantedBy=sanoid.service

--- a/templates/sanoid.conf.j2
+++ b/templates/sanoid.conf.j2
@@ -4,11 +4,11 @@
     recursive = {{ 'yes' if (dataset.recursive | default(False)) else 'no' }}
     process_children_only = {{ 'yes' if (dataset.process_children_only | default(False)) else 'no' }}
     skip_children = {{ 'yes' if (dataset.skip_children | default(False)) else 'no' }}
-{% if dataset.overrides | default([]) | length > 0 %}
-{% for setting, value in dataset.overrides.items() %}
+{%  if dataset.overrides | default([]) | length > 0 %}
+{%   for setting, value in dataset.overrides.items() %}
     {{ setting }} = {{ value }}
-{% endfor %}
-{% endif %}
+{%   endfor %}
+{%  endif %}
 {% endfor %}
 
 
@@ -18,9 +18,9 @@
 
 {% for template in sanoid_templates %}
 [template_{{ template.name }}]
-{% for setting, value in template.items() %}
-{% if setting != 'name' %}
+{%  for setting, value in template.items() %}
+{%   if setting != 'name' %}
     {{ setting }} = {{ value }}
-{% endif %}
-{% endfor %}
+{%   endif %}
+{%  endfor %}
 {% endfor %}

--- a/templates/sanoid.service.j2
+++ b/templates/sanoid.service.j2
@@ -10,13 +10,13 @@ ConditionFileNotEmpty={{ sanoid_conf }}
 Environment=TZ=UTC
 Type=oneshot
 ExecStart={{ sanoid_path | default(sanoid_bin_path) }} --take-snapshots --verbose
-{% if sanoid_systemd_ExecStartPre is defined and sanoid_systemd_ExecStartPre %}
-{% for exec in sanoid_systemd_ExecStartPre %}
+{% if sanoid_service_pre_start is defined and sanoid_service_pre_start %}
+{%  for exec in sanoid_service_pre_start %}
 ExecStartPre={{ exec }}
-{% endfor %}
+{%  endfor %}
 {% endif %}
-{% if sanoid_systemd_ExecStartPost is defined and sanoid_systemd_ExecStartPost %}
-{% for exec in sanoid_systemd_ExecStartPost %}
+{% if sanoid_service_post_start is defined and sanoid_service_post_start %}
+{%  for exec in sanoid_service_post_start %}
 ExecStartPost={{ exec }}
-{% endfor %}
+{%  endfor %}
 {% endif %}

--- a/templates/sanoid.service.j2
+++ b/templates/sanoid.service.j2
@@ -10,3 +10,13 @@ ConditionFileNotEmpty={{ sanoid_conf }}
 Environment=TZ=UTC
 Type=oneshot
 ExecStart={{ sanoid_path | default(sanoid_bin_path) }} --take-snapshots --verbose
+{% if sanoid_systemd_ExecStartPre is defined and sanoid_systemd_ExecStartPre %}
+{% for exec in sanoid_systemd_ExecStartPre %}
+ExecStartPre={{ exec }}
+{% endfor %}
+{% endif %}
+{% if sanoid_systemd_ExecStartPost is defined and sanoid_systemd_ExecStartPost %}
+{% for exec in sanoid_systemd_ExecStartPost %}
+ExecStartPost={{ exec }}
+{% endfor %}
+{% endif %}

--- a/templates/service.override.conf.j2
+++ b/templates/service.override.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for systemd_service_override in systemd_service_overrides %}
+{{ systemd_service_override_type }}={{ systemd_service_override }}
+{% endfor%}

--- a/templates/service.override.conf.j2
+++ b/templates/service.override.conf.j2
@@ -1,4 +1,4 @@
 [Service]
 {% for systemd_service_override in systemd_service_overrides %}
 {{ systemd_service_override_type }}={{ systemd_service_override }}
-{% endfor%}
+{% endfor %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -73,7 +73,6 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
 {% if sync.no_clone_handling | default(False) %}
   --no-clone-handling \
 {% endif %}
-
 {% if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -1,92 +1,90 @@
 [Unit]
-Description=Replicate sanoid snapshots
+Description=Replicate sanoid {{ syncoid_sync_name }} snapshots
 Requires=zfs.target
-After=zfs.target
+After=zfs.target {{ syncoid_after_services | map('regex_replace', '$', '.service') | join(' ') }}
 
 [Service]
 Type=oneshot
-{% for sync in syncoid_syncs %}
 ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
-{%  if sync.identifier | default('') %}
-  --identifier={{ sync.identifier }} \
-{%  endif %}
-{%  if sync.force_delete | default(False) %}
+{%  if syncoid_sync.identifier | default('') %}
+  --identifier={{ syncoid_sync.identifier }} \
+{% endif %}
+{% if syncoid_sync.force_delete | default(False) %}
   --force-delete \
-{%  endif %}
-{%  if sync.recursive | default(False) %}
+{% endif %}
+{% if syncoid_sync.recursive | default(False) %}
   --recursive \
-{%   if sync.skip_parent | default(False) %}
+{%  if syncoid_sync.skip_parent | default(False) %}
   --skip-parent \ {# only relevant if --recursive #}
-{%   endif %}
 {%  endif %}
-{%  if sync.compress | default('') %}
-  --compress={{ sync.compress }} \
-{%  endif %}
-{%  if sync.source_bwlimit | default('') %}
-  --source-bwlimit={{ sync.source_bwlimit }} \
-{%  endif %}
-{%  if sync.target_bwlimit | default('') %}
-  --target-bwlimit={{ sync.target_bwlimit }} \
-{%  endif %}
-{%  if sync.mbuffer_size | default('') %}
-  --mbuffer-size={{ sync.mbuffer_size }} \
-{%  endif %}
-{%  if sync.pv_options | default('') %}
-  --pv-options={{ sync.pv_options }} \
-{%  endif %}
-{%  if sync.no_stream | default(False) %}
+{% endif %}
+{% if syncoid_sync.compress | default('') %}
+  --compress={{ syncoid_sync.compress }} \
+{% endif %}
+{% if syncoid_sync.source_bwlimit | default('') %}
+  --source-bwlimit={{ syncoid_sync.source_bwlimit }} \
+{% endif %}
+{% if syncoid_sync.target_bwlimit | default('') %}
+  --target-bwlimit={{ syncoid_sync.target_bwlimit }} \
+{% endif %}
+{% if syncoid_sync.mbuffer_size | default('') %}
+  --mbuffer-size={{ syncoid_sync.mbuffer_size }} \
+{% endif %}
+{% if syncoid_sync.pv_options | default('') %}
+  --pv-options={{ syncoid_sync.pv_options }} \
+{% endif %}
+{% if syncoid_sync.no_stream | default(False) %}
   --no-stream \
-{%  endif %}
-{%  if sync.no_sync_snap | default(False) %}
+{% endif %}
+{% if syncoid_sync.no_sync_snap | default(False) %}
   --no-sync-snap \
-{%   if sync.create_bookmark | default(False) %}
+{%  if syncoid_sync.create_bookmark | default(False) %}
   --create-bookmark \
-{%   endif %}
 {%  endif %}
-{%  if sync.keep_sync_snap | default(False) %}
+{% endif %}
+{% if syncoid_sync.keep_sync_snap | default(False) %}
   --keep-sync-snap \
-{%  endif %}
-{%  if sync.preserve_recordsize | default(True) %}
+{% endif %}
+{% if syncoid_sync.preserve_recordsize | default(True) %}
   --preserve-recordsize \
-{%  endif %}
-{%  if sync.no_clone_rollback | default(False) %}
+{% endif %}
+{% if syncoid_sync.no_clone_rollback | default(False) %}
   --no-clone-rollback \
-{%  endif %}
-{%  if sync.no_rollback | default(False) %}
+{% endif %}
+{% if syncoid_sync.no_rollback | default(False) %}
   --no-rollback \
-{%  endif %}
-{%  for sync_exclude in sync.exclude | default([]) %}
+{% endif %}
+{% for sync_exclude in syncoid_sync.exclude | default([]) %}
   --exclude={{ sync_exclude }} \
-{%  endfor %}
-{%  if sync.send_options | default(syncoid_send_options) | default(False) %}
-  --sendoptions={{ sync.send_options | default(syncoid_send_options) }} \
-{%  endif %}
-{%  if sync.recv_options | default(syncoid_recv_options) | default(False) %}
-  --recvoptions={{ sync.recv_options | default(syncoid_recv_options) }} \
-{%  endif %}
-{%  if sync.no_privilege_escalation | default(False) %}
-  --no-privilege-escalation \
-{%  endif %}
-{%  if sync.no_resume | default(False) %}
-  --no-resume \
-{%  endif %}
-{%  if sync.no_clone_handling | default(False) %}
-  --no-clone-handling \
-{%  endif %}
-{%  if syncoid_use_ssh_key | default(False) %}
-  --sshkey {{ syncoid_ssh_key }} \
-{%  endif %}
-{%  if sync.src_host | default('') %}
-  {{ sync.src_user | default('root') }}@{{ sync.src_host }}:{{ sync.src | mandatory }} \
-{%  else %}
-  {{ sync.src }} \
-{%  endif %}
-{%  if sync.dest_host | default('') %}
-  {{ sync.dest_user | default('root') }}@{{ sync.dest_host }}:{{ sync.dest | mandatory }}
-{%  else %}
-  {{ sync.dest }}
-{%  endif %}
 {% endfor %}
+{% if syncoid_sync.send_options | default(syncoid_send_options) | default(False) %}
+  --sendoptions={{ syncoid_sync.send_options | default(syncoid_send_options) }} \
+{% endif %}
+{% if syncoid_sync.recv_options | default(syncoid_recv_options) | default(False) %}
+  --recvoptions={{ syncoid_sync.recv_options | default(syncoid_recv_options) }} \
+{% endif %}
+{% if syncoid_sync.no_privilege_escalation | default(False) %}
+  --no-privilege-escalation \
+{% endif %}
+{% if syncoid_sync.no_resume | default(False) %}
+  --no-resume \
+{% endif %}
+{% if syncoid_sync.no_clone_handling | default(False) %}
+  --no-clone-handling \
+{% endif %}
+{% if syncoid_use_ssh_key | default(False) %}
+  --sshkey {{ syncoid_ssh_key }} \
+{% endif %}
+{% if syncoid_sync.src_host | default('') %}
+  {{ syncoid_sync.src_user | default('root') }}@{{ syncoid_sync.src_host }}:{{ syncoid_sync.src | mandatory }} \
+{% else %}
+  {{ syncoid_sync.src }} \
+{% endif %}
+{% if syncoid_sync.dest_host | default('') %}
+  {{ syncoid_sync.dest_user | default('root') }}@{{ syncoid_sync.dest_host }}:{{ syncoid_sync.dest | mandatory }}
+{% else %}
+  {{ syncoid_sync.dest }}
+{% endif %}
 {% if syncoid_service_pre_start is defined and syncoid_service_pre_start %}
 {%  for exec in syncoid_service_pre_start %}
 ExecStartPre={{ exec }}
@@ -97,3 +95,6 @@ ExecStartPre={{ exec }}
 ExecStartPost={{ exec }}
 {%  endfor %}
 {% endif %}
+
+[Install]
+WantedBy={{ syncoid_service_name }}.target

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -1,3 +1,11 @@
+{%- macro healthcheck(sync) -%}
+{%-  if sync.healthchecks is defined -%}
+{{ syncoid_healthchecks_runitor_binary }} -create -- {{ syncoid_path | default(syncoid_bin_path) }} \
+{%-  else -%}
+{{ syncoid_path | default(syncoid_bin_path) }} \
+{%-  endif -%}
+{%- endmacro -%}
+
 [Unit]
 Description=Replicate sanoid {{ syncoid_sync_name }} snapshots
 Requires=zfs.target
@@ -5,7 +13,12 @@ After=zfs.target {{ syncoid_after_services | map('regex_replace', '$', '.service
 
 [Service]
 Type=oneshot
-ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
+{% if syncoid_sync.healthchecks is defined %}
+Environment="HC_API_URL={{ syncoid_sync.healthchecks.api_url | default(syncoid_healthchecks_api_url) | default('https://hc-ping.com') }}"
+Environment="PING_KEY={{ syncoid_sync.healthchecks.ping_key | default(syncoid_healthchecks_ping_key) }}"
+Environment="CHECK_SLUG={{ syncoid_sync.healthchecks.slug }}"
+{% endif %}
+ExecStart={{ healthcheck(syncoid_sync) }}
 {%  if syncoid_sync.identifier | default('') %}
   --identifier={{ syncoid_sync.identifier }} \
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -47,7 +47,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --keep-sync-snap \
 {% endif %}
 {% if sync.preserve_recordsize | default(False) %}
-  --preserve-recordsize
+  --preserve-recordsize \
 {% endif %}
 {% if sync.no_clone_rollback | default(False) %}
   --no-clone-rollback \
@@ -56,7 +56,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --no-rollback \
 {% endif %}
 {% for sync_exclude in sync.exclude | default([]) %}
-  --exclude={{ sync_exclude }}
+  --exclude={{ sync_exclude }} \
 {% endfor %}
 {% if sync.sendoptions | default('') %}
   --sendoptions={{ sync.sendoptions }} \
@@ -73,7 +73,6 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
 {% if sync.no_clone_handling | default(False) %}
   --no-clone-handling \
 {% endif %}
-
 {% if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -87,3 +87,13 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   {{ sync.dest }}
 {% endif %}
 {% endfor %}
+{% if syncoid_systemd_ExecStartPre is defined and syncoid_systemd_ExecStartPre %}
+{% for exec in syncoid_systemd_ExecStartPre %}
+ExecStartPre={{ exec }}
+{% endfor %}
+{% endif %}
+{% if syncoid_systemd_ExecStartPost is defined and syncoid_systemd_ExecStartPost %}
+{% for exec in syncoid_systemd_ExecStartPost %}
+ExecStartPost={{ exec }}
+{% endfor %}
+{% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -98,15 +98,17 @@ ExecStart={{ healthcheck(syncoid_sync) }}
 {% else %}
   {{ syncoid_sync.dest }}
 {% endif %}
-{% if syncoid_service_pre_start is defined and syncoid_service_pre_start %}
-{%  for exec in syncoid_service_pre_start %}
+{% if syncoid_sync.systemd is defined %}
+{%  if syncoid_sync.systemd.pre_start is defined and syncoid_sync.systemd.pre_start %}
+{%   for exec in syncoid_sync.systemd.pre_start %}
 ExecStartPre={{ exec }}
-{%  endfor %}
-{% endif %}
-{% if syncoid_service_post_start is defined and syncoid_service_post_start %}
-{%  for exec in syncoid_service_post_start %}
+{%   endfor %}
+{%  endif %}
+{%  if syncoid_sync.systemd.post_start is defined and syncoid_sync.systemd.post_start %}
+{%   for exec in syncoid_sync.systemd.post_start %}
 ExecStartPost={{ exec }}
-{%  endfor %}
+{%   endfor %}
+{%  endif %}
 {% endif %}
 
 [Install]

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -87,13 +87,13 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   {{ sync.dest }}
 {% endif %}
 {% endfor %}
-{% if syncoid_systemd_ExecStartPre is defined and syncoid_systemd_ExecStartPre %}
-{% for exec in syncoid_systemd_ExecStartPre %}
+{% if syncoid_service_pre_start is defined and syncoid_service_pre_start %}
+{%  for exec in syncoid_service_pre_start %}
 ExecStartPre={{ exec }}
-{% endfor %}
+{%  endfor %}
 {% endif %}
-{% if syncoid_systemd_ExecStartPost is defined and syncoid_systemd_ExecStartPost %}
-{% for exec in syncoid_systemd_ExecStartPost %}
+{% if syncoid_service_post_start is defined and syncoid_service_post_start %}
+{%  for exec in syncoid_service_post_start %}
 ExecStartPost={{ exec }}
-{% endfor %}
+{%  endfor %}
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -47,7 +47,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --keep-sync-snap \
 {% endif %}
 {% if sync.preserve_recordsize | default(False) %}
-  --preserve-recordsize
+  --preserve-recordsize \
 {% endif %}
 {% if sync.no_clone_rollback | default(False) %}
   --no-clone-rollback \
@@ -56,7 +56,7 @@ ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
   --no-rollback \
 {% endif %}
 {% for sync_exclude in sync.exclude | default([]) %}
-  --exclude={{ sync_exclude }}
+  --exclude={{ sync_exclude }} \
 {% endfor %}
 {% if sync.sendoptions | default('') %}
   --sendoptions={{ sync.sendoptions }} \

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -14,7 +14,7 @@ After=zfs.target {{ syncoid_after_services | map('regex_replace', '$', '.service
 [Service]
 Type=oneshot
 {% if syncoid_sync.healthchecks is defined %}
-Environment="HC_API_URL={{ syncoid_sync.healthchecks.api_url | default(syncoid_healthchecks_api_url) | default('https://hc-ping.com') }}"
+Environment="HC_API_URL={{ syncoid_sync.healthchecks.api_url | default(syncoid_healthchecks_api_url) }}"
 Environment="PING_KEY={{ syncoid_sync.healthchecks.ping_key | default(syncoid_healthchecks_ping_key) }}"
 Environment="CHECK_SLUG={{ syncoid_sync.healthchecks.slug }}"
 {% endif %}

--- a/templates/syncoid.service.j2
+++ b/templates/syncoid.service.j2
@@ -7,85 +7,85 @@ After=zfs.target
 Type=oneshot
 {% for sync in syncoid_syncs %}
 ExecStart={{ syncoid_path | default(syncoid_bin_path) }} \
-{% if sync.identifier | default('') %}
+{%  if sync.identifier | default('') %}
   --identifier={{ sync.identifier }} \
-{% endif %}
-{% if sync.force_delete | default(False) %}
+{%  endif %}
+{%  if sync.force_delete | default(False) %}
   --force-delete \
-{% endif %}
-{% if sync.recursive | default(False) %}
+{%  endif %}
+{%  if sync.recursive | default(False) %}
   --recursive \
-{% if sync.skip_parent | default(False) %}
+{%   if sync.skip_parent | default(False) %}
   --skip-parent \ {# only relevant if --recursive #}
-{% endif %}
-{% endif %}
-{% if sync.compress | default('') %}
+{%   endif %}
+{%  endif %}
+{%  if sync.compress | default('') %}
   --compress={{ sync.compress }} \
-{% endif %}
-{% if sync.source_bwlimit | default('') %}
+{%  endif %}
+{%  if sync.source_bwlimit | default('') %}
   --source-bwlimit={{ sync.source_bwlimit }} \
-{% endif %}
-{% if sync.target_bwlimit | default('') %}
+{%  endif %}
+{%  if sync.target_bwlimit | default('') %}
   --target-bwlimit={{ sync.target_bwlimit }} \
-{% endif %}
-{% if sync.mbuffer_size | default('') %}
+{%  endif %}
+{%  if sync.mbuffer_size | default('') %}
   --mbuffer-size={{ sync.mbuffer_size }} \
-{% endif %}
-{% if sync.pv_options | default('') %}
+{%  endif %}
+{%  if sync.pv_options | default('') %}
   --pv-options={{ sync.pv_options }} \
-{% endif %}
-{% if sync.no_stream | default(False) %}
+{%  endif %}
+{%  if sync.no_stream | default(False) %}
   --no-stream \
-{% endif %}
-{% if sync.no_sync_snap | default(False) %}
+{%  endif %}
+{%  if sync.no_sync_snap | default(False) %}
   --no-sync-snap \
-{% if sync.create_bookmark | default(False) %}
+{%   if sync.create_bookmark | default(False) %}
   --create-bookmark \
-{% endif %}
-{% endif %}
-{% if sync.keep_sync_snap | default(False) %}
+{%   endif %}
+{%  endif %}
+{%  if sync.keep_sync_snap | default(False) %}
   --keep-sync-snap \
-{% endif %}
-{% if sync.preserve_recordsize | default(True) %}
+{%  endif %}
+{%  if sync.preserve_recordsize | default(True) %}
   --preserve-recordsize \
-{% endif %}
-{% if sync.no_clone_rollback | default(False) %}
+{%  endif %}
+{%  if sync.no_clone_rollback | default(False) %}
   --no-clone-rollback \
-{% endif %}
-{% if sync.no_rollback | default(False) %}
+{%  endif %}
+{%  if sync.no_rollback | default(False) %}
   --no-rollback \
-{% endif %}
-{% for sync_exclude in sync.exclude | default([]) %}
+{%  endif %}
+{%  for sync_exclude in sync.exclude | default([]) %}
   --exclude={{ sync_exclude }} \
-{% endfor %}
-{% if sync.send_options | default(syncoid_send_options) | default(False) %}
+{%  endfor %}
+{%  if sync.send_options | default(syncoid_send_options) | default(False) %}
   --sendoptions={{ sync.send_options | default(syncoid_send_options) }} \
-{% endif %}
-{% if sync.recv_options | default(syncoid_recv_options) | default(False) %}
+{%  endif %}
+{%  if sync.recv_options | default(syncoid_recv_options) | default(False) %}
   --recvoptions={{ sync.recv_options | default(syncoid_recv_options) }} \
-{% endif %}
-{% if sync.no_privilege_escalation | default(False) %}
+{%  endif %}
+{%  if sync.no_privilege_escalation | default(False) %}
   --no-privilege-escalation \
-{% endif %}
-{% if sync.no_resume | default(False) %}
+{%  endif %}
+{%  if sync.no_resume | default(False) %}
   --no-resume \
-{% endif %}
-{% if sync.no_clone_handling | default(False) %}
+{%  endif %}
+{%  if sync.no_clone_handling | default(False) %}
   --no-clone-handling \
-{% endif %}
-{% if syncoid_use_ssh_key | default(False) %}
+{%  endif %}
+{%  if syncoid_use_ssh_key | default(False) %}
   --sshkey {{ syncoid_ssh_key }} \
-{% endif %}
-{% if sync.src_host | default('') %}
+{%  endif %}
+{%  if sync.src_host | default('') %}
   {{ sync.src_user | default('root') }}@{{ sync.src_host }}:{{ sync.src | mandatory }} \
-{% else %}
+{%  else %}
   {{ sync.src }} \
-{% endif %}
-{% if sync.dest_host | default('') %}
+{%  endif %}
+{%  if sync.dest_host | default('') %}
   {{ sync.dest_user | default('root') }}@{{ sync.dest_host }}:{{ sync.dest | mandatory }}
-{% else %}
+{%  else %}
   {{ sync.dest }}
-{% endif %}
+{%  endif %}
 {% endfor %}
 {% if syncoid_service_pre_start is defined and syncoid_service_pre_start %}
 {%  for exec in syncoid_service_pre_start %}

--- a/templates/syncoid.target.j2
+++ b/templates/syncoid.target.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Replicate sanoid snapshots
+Requires=zfs.target
+After=zfs.target
+{# Wants are explicitly listed here to allow cleanup when removing services, as ansible.builtin.systemd
+   cannot detect the implicit Wants created by the WantedBy declarations in the unit files #}
+Wants={{ syncoid_service_names | map('regex_replace', '$', '.service') | join(' ') }}
+StopWhenUnneeded=true
+
+[Install]
+WantedBy={{ syncoid_service_name }}.timer
+Also={{ syncoid_service_name }}.timer
+{% for syncoid_sync_service in syncoid_service_names %}
+Also={{ syncoid_sync_service }}.service
+{% endfor %}

--- a/templates/syncoid.timer.j2
+++ b/templates/syncoid.timer.j2
@@ -4,6 +4,7 @@ Description=Run Syncoid {{ syncoid_timer_frequency }}
 [Timer]
 OnCalendar={{ syncoid_timer_frequency }}
 Persistent=true
+Unit={{ syncoid_service_name }}.target
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Split monolithic syncoid systemd service into separate services per defined sync, with a group target activated by the timer. This allows for starting individual syncs as needed, as well as starting the entire sync job both manually and via the configured timer.

Also adds basic Healthchecks.io support on a per sync basis.