### PR TITLE
Fix: Prevent syncoid timer deletion when timer does not exist.

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -204,6 +204,9 @@
         enabled: false
         masked: no
       notify: reload systemd
+      when: >
+        ansible_facts.services is defined and
+        ('{{ syncoid_service_name | default('') }}.timer' in ansible_facts.services.keys())
 
     - name: remove syncoid systemd sync services
       ansible.builtin.include_tasks: "systemd-remove.yaml"


### PR DESCRIPTION
This fixes an error that resulted when the role tried to delete a systemd timer that did not exist. The specific host in use had sanoid entries, but no syncs configured, which I suspect is the root cause.